### PR TITLE
Allow passing a presupplied JWT for API client authorization.

### DIFF
--- a/edx_rest_api_client/auth.py
+++ b/edx_rest_api_client/auth.py
@@ -37,6 +37,19 @@ class JwtAuth(AuthBase):
         return r
 
 
+class SuppliedJwtAuth(AuthBase):
+    """Attaches a supplied JWT to the given Request object."""
+
+    def __init__(self, token):
+        """Instantiate the auth class."""
+        self.token = token
+
+    def __call__(self, r):
+        """Update the request headers."""
+        r.headers['Authorization'] = 'JWT {jwt}'.format(jwt=self.token)
+        return r
+
+
 class BearerAuth(AuthBase):
     """ Attaches Bearer Authentication to the given Request object. """
 

--- a/edx_rest_api_client/client.py
+++ b/edx_rest_api_client/client.py
@@ -1,13 +1,13 @@
 import requests
 import slumber
 
-from edx_rest_api_client.auth import JwtAuth, BearerAuth
+from edx_rest_api_client.auth import BearerAuth, JwtAuth, SuppliedJwtAuth
 
 
 class EdxRestApiClient(slumber.API):
     def __init__(self, url, signing_key=None, username=None, full_name=None, email=None,
                  timeout=5, issuer=None, expires_in=30, tracking_context=None, oauth_access_token=None,
-                 session=None):
+                 session=None, jwt=None):
         """
         Instantiate a new client.
 
@@ -18,13 +18,15 @@ class EdxRestApiClient(slumber.API):
         if not url:
             raise ValueError('An API url must be supplied!')
 
-        if oauth_access_token:
+        if jwt:
+            auth = SuppliedJwtAuth(jwt)
+        elif oauth_access_token:
             auth = BearerAuth(oauth_access_token)
         elif signing_key and username:
             auth = JwtAuth(username, full_name, email, signing_key,
                            issuer=issuer, expires_in=expires_in, tracking_context=tracking_context)
         else:
-            raise ValueError('Either JWT or OAuth2 credentials must be suppled for authentication!')
+            raise ValueError('Either JWT or OAuth2 credentials must be supplied for authentication!')
 
         session = session or requests.Session()
         session.timeout = timeout

--- a/edx_rest_api_client/tests/test_auth.py
+++ b/edx_rest_api_client/tests/test_auth.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 
 import datetime
 from unittest import TestCase
@@ -102,3 +102,25 @@ class BearerAuthTests(TestCase):
         token = 'abc123'
         requests.get(self.url, auth=auth.BearerAuth(token))
         self.assertEqual(httpretty.last_request().headers['Authorization'], 'Bearer {}'.format(token))
+
+
+class SuppliedJwtAuthTests(TestCase):
+
+    signing_key = 'super-secret'
+    url = 'http://example.com/'
+
+    def setUp(self):
+        """Set up tests."""
+        super(SuppliedJwtAuthTests, self).setUp()
+        httpretty.register_uri(httpretty.GET, self.url)
+
+    @httpretty.activate
+    def test_headers(self):
+        """Verify that the token is added to the Authorization headers."""
+        payload = {
+            u'key1': u'value1',
+            u'key2': u'vαlue2'
+        }
+        token = jwt.encode(payload, self.signing_key)
+        requests.get(self.url, auth=auth.SuppliedJwtAuth(token))
+        self.assertEqual(httpretty.last_request().headers['Authorization'], 'JWT {}'.format(token))

--- a/edx_rest_api_client/tests/test_client.py
+++ b/edx_rest_api_client/tests/test_client.py
@@ -14,6 +14,7 @@ FULL_NAME = 'édx äpp'
 EMAIL = 'edx@example.com'
 TRACKING_CONTEXT = {'foo': 'bar'}
 ACCESS_TOKEN = 'abc123'
+JWT = 'abc.123.doremi'
 
 
 @ddt.ddt
@@ -52,3 +53,9 @@ class EdxRestApiClientTests(TestCase):
         with mock.patch('edx_rest_api_client.auth.BearerAuth.__init__', return_value=None) as mock_auth:
             EdxRestApiClient(URL, oauth_access_token=ACCESS_TOKEN)
             mock_auth.assert_called_with(ACCESS_TOKEN)
+
+    def test_supplied_jwt(self):
+        """Ensure JWT authentication is used when a JWT is supplied to the constructor."""
+        with mock.patch('edx_rest_api_client.auth.SuppliedJwtAuth.__init__', return_value=None) as mock_auth:
+            EdxRestApiClient(URL, jwt=JWT)
+            mock_auth.assert_called_with(JWT)


### PR DESCRIPTION
This will be used by the async fulfillment work.

@renzo @clintonb @bderusha @rock345 