### PR TITLE
Pin install_requires versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
-PyJWT==1.1.0
-slumber==0.7.1
+# These requirements are for development.  There is no need to install from
+# requirements.txt in production.
+
+# Package requirements
+-e .
 
 # Testing
 coverage==3.7.1

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as readme:
 
 setup(
     name='edx-rest-api-client',
-    version='1.2.1',
+    version='1.2.2',
     description='Slumber client used to access various edX Platform REST APIs.',
     long_description=long_description,
     classifiers=[
@@ -24,5 +24,5 @@ setup(
     author_email='oscm@edx.org',
     license='Apache',
     packages=find_packages(exclude=['*.tests']),
-    install_requires=['slumber', 'PyJWT'],
+    install_requires=['slumber >= 0.7.1, < 1.0', 'PyJWT >= 1.1.0, < 2.0'],
 )


### PR DESCRIPTION
I recently replaced an old version of slumber in Insights with the edx-rest-api-client. Since the slumber version is unspecified in this repo's `setup.py`, the client happily installed with an old buggy version of slumber, which caused a pretty sneaky auth bug (see https://github.com/samgiles/slumber/issues/79).

I'm pinning version in install_requires as `>=` the corresponding versions specified in `requirements.txt` to prevent this type of bug.