### PR TITLE
Add method to support client_credential flow for access token retrieval

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Clinton Blackburn <cblackburn@edx.org>
 Renzo Lucioni <renzo@edx.org>
 Michael Frey <mfrey@edx.org>
+Bill DeRusha <bill@edx.org>

--- a/edx_rest_api_client/tests/mixins.py
+++ b/edx_rest_api_client/tests/mixins.py
@@ -1,0 +1,20 @@
+""" Test mixins """
+import json
+
+import httpretty
+
+
+class AuthenticationTestMixin(object):
+    """ Mixin for testing authentication. """
+
+    def _mock_auth_api(self, url, status, body=None):
+        self.assertTrue(httpretty.is_enabled(), 'httpretty must be enabled to mock authentication API calls.')
+
+        body = body or {}
+        httpretty.register_uri(
+            httpretty.POST,
+            url,
+            status=status,
+            body=json.dumps(body),
+            content_type='application/json'
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,10 @@
 # Testing
 coverage==3.7.1
 ddt==1.0.0
+freezegun==0.3.6
 httpretty==0.8.8
 mock==1.0.1
 nose==1.3.6
 pep8==1.6.2
 pylint==1.5.0
+pytz==2015.7

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as readme:
 
 setup(
     name='edx-rest-api-client',
-    version='1.4.0',
+    version='1.5.0',
     description='Slumber client used to access various edX Platform REST APIs.',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
Moved client_credential flow to edx-rest-api-client from course-discovery.  Please review @clintonb @rlucioni 