### PR TITLE
Renamed EdxSession to OAuthAPIClient

### DIFF
--- a/edx_rest_api_client/client.py
+++ b/edx_rest_api_client/client.py
@@ -77,7 +77,7 @@ def get_oauth_access_token(url, client_id, client_secret, token_type='jwt', gran
     return access_token, expires_at
 
 
-class EdxSession(requests.Session):
+class OAuthAPIClient(requests.Session):
     """
     A :class:`requests.Session` that automatically authenticates against edX's preferred
     authentication method, given a client id and client secret. The underlying implementation
@@ -92,7 +92,7 @@ class EdxSession(requests.Session):
             client_id (str): Client ID
             client_secret (str): Client secret
         """
-        super(EdxSession, self).__init__(**kwargs)
+        super(OAuthAPIClient, self).__init__(**kwargs)
         self.headers['user-agent'] = USER_AGENT
         self._base_url = base_url
         self._client_id = client_id
@@ -116,7 +116,7 @@ class EdxSession(requests.Session):
         Overrides Session.request to ensure that the session is authenticated
         """
         self._check_auth()
-        return super(EdxSession, self).request(method, url, **kwargs)
+        return super(OAuthAPIClient, self).request(method, url, **kwargs)
 
 
 class EdxRestApiClient(slumber.API):
@@ -149,7 +149,7 @@ class EdxRestApiClient(slumber.API):
         if not url:
             raise ValueError('An API url must be supplied!')
 
-        warnings.warn('EdxRestApiClient is deprecated. Use EdxSession instead.')
+        warnings.warn('EdxRestApiClient is deprecated. Use OAuthAPIClient instead.')
 
         if jwt:
             auth = SuppliedJwtAuth(jwt)

--- a/edx_rest_api_client/tests/test_client.py
+++ b/edx_rest_api_client/tests/test_client.py
@@ -12,7 +12,7 @@ from freezegun import freeze_time
 
 from edx_rest_api_client import __version__
 from edx_rest_api_client.auth import JwtAuth
-from edx_rest_api_client.client import EdxRestApiClient, EdxSession, user_agent
+from edx_rest_api_client.client import EdxRestApiClient, OAuthAPIClient, user_agent
 from edx_rest_api_client.tests.mixins import AuthenticationTestMixin
 
 URL = 'http://example.com/api/v2'
@@ -132,9 +132,9 @@ class ClientCredentialTests(AuthenticationTestMixin, TestCase):
             EdxRestApiClient.get_oauth_access_token(URL, "client_id", "client_secret")
 
 
-class EdxSessionTests(AuthenticationTestMixin, TestCase):
+class OAuthAPIClientTests(AuthenticationTestMixin, TestCase):
     """
-    Tests for EdxSession
+    Tests for OAuthAPIClient
     """
     base_url = 'http://testing.test'
     client_id = 'test'
@@ -145,7 +145,7 @@ class EdxSessionTests(AuthenticationTestMixin, TestCase):
         """
         Test that the JWT token is automatically set
         """
-        session = EdxSession(self.base_url, self.client_id, self.client_secret)
+        session = OAuthAPIClient(self.base_url, self.client_id, self.client_secret)
         self._mock_auth_api(self.base_url + '/oauth2/access_token', 200, {'access_token': 'abcd', 'expires_in': 60})
         self._mock_auth_api(self.base_url + '/endpoint', 200, {'status': 'ok'})
         response = session.post(self.base_url + '/endpoint', data={'test': 'ok'})
@@ -172,7 +172,7 @@ class EdxSessionTests(AuthenticationTestMixin, TestCase):
             content_type='application/json',
         )
 
-        session = EdxSession(self.base_url, self.client_id, self.client_secret)
+        session = OAuthAPIClient(self.base_url, self.client_id, self.client_secret)
         self._mock_auth_api(self.base_url + '/endpoint', 200, {'status': 'ok'})
         response = session.post(self.base_url + '/endpoint', data={'test': 'ok'})
         self.assertEqual(session.auth.token, 'cred')


### PR DESCRIPTION
@nasthagiri I had already merged the other branch. So here's the rename of EdxSession to OAuthAPIClient.