### PR TITLE
BOM-1184- Don't force an upgrade of pip.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ cache:
   - pip
 
 install:
-  - pip install -U pip wheel codecov
   - pip install -r requirements/travis.txt
 
 script:


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1184

This seems to be a common issue with upgrades to pip: https://github.com/pypa/pip/issues/5599

```Only ever use your system package manager to upgrade the system pip. The system installed pip is owned by the distribution, and if you don't use distribution-supplied tools to manage it, you will hit problems. Yes, we know pip says "you should upgrade with pip install -U pip" - that's true in a pip-managed installation, ideally distributions should patch this message to give appropriate instructions in the system pip, but they don't. We're working with them on this, but it's not going to happen soon (remember, we're looking at cases where people are upgrading old versions of pip here, so patches to new versions won't help).```