### PR TITLE
enhance auth docs and metric

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,12 @@ Testing
 -------
     $ make validate
 
+
+Clients & REST API Clients code
+-------------------------------
+
+Open edX services, including LMS, should use the OAuthAPIClient class to make OAuth2 client requests and REST API calls.
+
 Additional Requirements
 -----------------------
 

--- a/edx_rest_api_client/auth.py
+++ b/edx_rest_api_client/auth.py
@@ -1,11 +1,21 @@
 import datetime
 
 import jwt
+from edx_django_utils.monitoring import set_custom_metric
 from requests.auth import AuthBase
 
 
+# pylint: disable=line-too-long
 class JwtAuth(AuthBase):
-    """Attaches JWT Authentication to the given Request object."""
+    """
+    Attaches JWT Authentication to the given Request object.
+
+    Deprecated:
+        See https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0008-use-asymmetric-jwts.rst
+
+    Note: Remove pyjwt dependency when this class is removed.
+
+    """
 
     def __init__(self, username, full_name, email, signing_key, issuer=None, expires_in=30, tracking_context=None):
         self.issuer = issuer
@@ -34,6 +44,7 @@ class JwtAuth(AuthBase):
         if self.tracking_context is not None:
             data['tracking_context'] = self.tracking_context
 
+        set_custom_metric('deprecated_jwt_signing', 'JwtAuth')
         r.headers['Authorization'] = 'JWT {jwt}'.format(jwt=jwt.encode(data, self.signing_key))
         return r
 


### PR DESCRIPTION
* moved docs from edx-platform oauth_dispatch README.
* clarified JwtAuth is Deprecated.
* added metric 'deprecated_jwt_signing' with value 'JwtAuth' to help
 find usage.