### PR TITLE
BOM-1296 - Get make upgrade working.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,14 +6,15 @@
 #
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-django-waffle==0.19.0     # via edx-django-utils
-django==1.11.27           # via edx-django-utils
-edx-django-utils==2.0.3
+django-waffle==0.20.0     # via edx-django-utils
+django==1.11.28           # via edx-django-utils
+edx-django-utils==3.0
 idna==2.8                 # via requests
-newrelic==5.4.1.134       # via edx-django-utils
+newrelic==5.6.0.135       # via edx-django-utils
 psutil==1.2.1             # via edx-django-utils
 pyjwt==1.7.1
+pytz==2019.3              # via django
 requests==2.22.0
 six==1.14.0               # via django-waffle
 slumber==0.7.1
-urllib3==1.25.7           # via requests
+urllib3==1.25.8           # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -26,3 +26,9 @@ pytest<5.0.0
 
 # Constrained for Python 2 support
 Django<2.0.0
+
+# Constrained for Python 2.7 and 3.5 support
+mock==3.0.5
+
+# Constrained for python 2.7 and 3.5 support
+zipp==1.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,9 +4,10 @@
 #
 #    make upgrade
 #
+appdirs==1.4.3
 astroid==1.5.3
-atomicwrites==1.3.0       # via pytest
-attrs==19.3.0             # via pytest
+atomicwrites==1.3.0
+attrs==19.3.0
 certifi==2019.11.28
 chardet==3.0.4
 click-log==0.3.2
@@ -14,22 +15,24 @@ click==7.0
 codecov==2.0.15
 coverage==5.0.3
 ddt==1.2.2
-django-waffle==0.19.0
-django==1.11.27
-edx-django-utils==2.0.3
+distlib==0.3.0
+django-waffle==0.20.0
+django==1.11.28
+edx-django-utils==3.0
 edx-lint==1.3.1
 filelock==3.0.12
-freezegun==0.3.13
+freezegun==0.3.15
 idna==2.8
-importlib-metadata==1.4.0
+importlib-metadata==1.5.0
+importlib-resources==1.0.2
 isort==4.3.21
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
 mock==3.0.5
 more-itertools==5.0.0
-newrelic==5.4.1.134
-packaging==20.0
-pip-tools==4.3.0
+newrelic==5.6.0.135
+packaging==20.1
+pip-tools==4.4.1
 pluggy==0.13.1
 psutil==1.2.1
 py==1.8.1
@@ -50,10 +53,10 @@ responses==0.10.9
 six==1.14.0
 slumber==0.7.1
 toml==0.10.0
-tox-battery==0.5.1
-tox==3.14.3
-urllib3==1.25.7
-virtualenv==16.7.9
-wcwidth==0.1.8            # via pytest
-wrapt==1.11.2
-zipp==1.0.0
+tox-battery==0.5.2
+tox==3.14.5
+urllib3==1.25.8
+virtualenv==20.0.4
+wcwidth==0.1.8
+wrapt==1.12.0
+zipp==1.2.0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==4.3.0
+pip-tools==4.4.1
 six==1.14.0               # via pip-tools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,37 +5,47 @@
 #    make upgrade
 #
 astroid==1.5.3            # via pylint, pylint-celery
+atomicwrites==1.3.0       # via pytest
+attrs==19.3.0             # via pytest
 certifi==2019.11.28
 chardet==3.0.4
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint
 coverage==5.0.3           # via pytest-cov
 ddt==1.2.2
-django-waffle==0.19.0
-edx-django-utils==2.0.3
+django-waffle==0.20.0
+edx-django-utils==3.0
 edx-lint==1.3.1
-freezegun==0.3.13
+freezegun==0.3.15
 idna==2.8
+importlib-metadata==1.5.0  # via pluggy, pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 mock==3.0.5
-newrelic==5.4.1.134
+more-itertools==5.0.0     # via pytest
+newrelic==5.6.0.135
+packaging==20.1           # via pytest
+pluggy==0.13.1            # via pytest
 psutil==1.2.1
+py==1.8.1                 # via pytest
 pycodestyle==2.5.0
 pyjwt==1.7.1
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1
 pytest-django==3.8.0
 pytest==4.6.9             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via freezegun
-pytz==2019.3              # via django
+pytz==2019.3
 requests==2.22.0
 responses==0.10.9
 six==1.14.0
 slumber==0.7.1
-urllib3==1.25.7
-wrapt==1.11.2             # via astroid
+urllib3==1.25.8
+wcwidth==0.1.8            # via pytest
+wrapt==1.12.0             # via astroid
+zipp==1.2.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,23 +4,25 @@
 #
 #    make upgrade
 #
+appdirs==1.4.3            # via virtualenv
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
 coverage==5.0.3           # via codecov
-filelock==3.0.12          # via tox
+distlib==0.3.0            # via virtualenv
+filelock==3.0.12          # via tox, virtualenv
 idna==2.8                 # via requests
-importlib-metadata==1.4.0  # via pluggy, tox
-more-itertools==5.0.0     # via zipp
-packaging==20.0           # via tox
+importlib-metadata==1.5.0  # via pluggy, tox, virtualenv
+importlib-resources==1.0.2  # via virtualenv
+packaging==20.1           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
 pyparsing==2.4.6          # via packaging
 requests==2.22.0          # via codecov
-six==1.14.0               # via packaging, tox
+six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
-tox-battery==0.5.1
-tox==3.14.3
-urllib3==1.25.7           # via requests
-virtualenv==16.7.9        # via tox
-zipp==1.0.0               # via importlib-metadata
+tox-battery==0.5.2
+tox==3.14.5
+urllib3==1.25.8           # via requests
+virtualenv==20.0.4        # via tox
+zipp==1.2.0               # via importlib-metadata


### PR DESCRIPTION
Manually update pip-tools.txt to the latest first because there was an
issue with the version we had pinned.