### PR TITLE
Make sure oauth requests do not timeout during read

### DIFF
--- a/edx_rest_api_client/client.py
+++ b/edx_rest_api_client/client.py
@@ -20,7 +20,7 @@ ACCESS_TOKEN_EXPIRED_THRESHOLD_SECONDS = 5
 # How long should we wait to connect to the auth service.
 # https://requests.readthedocs.io/en/master/user/advanced/#timeouts
 REQUEST_CONNECT_TIMEOUT = 3.05
-REQUEST_READ_TIMEOUT = 1
+REQUEST_READ_TIMEOUT = 5
 
 
 def user_agent():


### PR DESCRIPTION
The previous default timeout of 1s was causing issues in communication
between services, in particular when the server was under load. This
timeout is configurable by passing a `timeout=...` keyword argument to
the OAuthClient constructor; but that requires patching every IDA. It
makes more sense to define a confortable timeout that can be overridden
individually by different IDA.

See these conversations:
https://github.com/edx/edx-rest-api-client/pull/62#issuecomment-646526313
https://discuss.overhang.io/t/error-during-new-setup-no-module-named-ecommerce-settings-tutor/681/9