### PR TITLE
Pinned importlib-metadata to 1.7.0 for python35

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ django-waffle==2.0.0      # via edx-django-utils
 django==2.2.16            # via -c requirements/constraints.txt, edx-django-utils
 edx-django-utils==3.8.0   # via -r requirements/base.in
 idna==2.10                # via requests
-newrelic==5.18.0.148      # via edx-django-utils
+newrelic==5.20.0.149      # via edx-django-utils
 pbr==5.5.0                # via stevedore
 psutil==5.7.2             # via edx-django-utils
 pyjwt==1.7.1              # via -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -22,3 +22,6 @@ twine<=1.15.0
 
 # constrain django to stay on LTS
 django<2.3
+
+# importlib-metadata>1.7.0 is causing conflicts in running make upgrade on python35
+importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,7 +7,7 @@
 appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==20.2.0             # via -r requirements/test.txt, pytest
-bleach==3.1.5             # via -r requirements/test.txt, readme-renderer
+bleach==3.2.1             # via -r requirements/test.txt, readme-renderer
 certifi==2020.6.20        # via -r requirements/test.txt, -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
@@ -24,7 +24,7 @@ edx-lint==1.5.2           # via -r requirements/test.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 freezegun==1.0.0          # via -r requirements/test.txt
 idna==2.10                # via -r requirements/test.txt, -r requirements/travis.txt, requests
-importlib-metadata==1.7.0  # via -r requirements/test.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
@@ -32,7 +32,7 @@ lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
 more-itertools==8.5.0     # via -r requirements/test.txt, pytest
-newrelic==5.18.0.148      # via -r requirements/test.txt, edx-django-utils
+newrelic==5.20.0.149      # via -r requirements/test.txt, edx-django-utils
 packaging==20.4           # via -r requirements/test.txt, -r requirements/travis.txt, bleach, pytest, tox
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.5.0                # via -r requirements/test.txt, stevedore
@@ -42,7 +42,7 @@ pluggy==0.13.1            # via -r requirements/test.txt, -r requirements/travis
 psutil==5.7.2             # via -r requirements/test.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/test.txt
-pygments==2.7.0           # via -r requirements/test.txt, readme-renderer
+pygments==2.7.1           # via -r requirements/test.txt, readme-renderer
 pyjwt==1.7.1              # via -r requirements/test.txt
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==20.2.0             # via pytest
-bleach==3.1.5             # via readme-renderer
+bleach==3.2.1             # via readme-renderer
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
@@ -19,14 +19,14 @@ edx-django-utils==3.8.0   # via -r requirements/base.txt
 edx-lint==1.5.2           # via -r requirements/test.in
 freezegun==1.0.0          # via -r requirements/test.in
 idna==2.10                # via -r requirements/base.txt, requests
-importlib-metadata==1.7.0  # via pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
 iniconfig==1.0.1          # via pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
 more-itertools==8.5.0     # via pytest
-newrelic==5.18.0.148      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.20.0.149      # via -r requirements/base.txt, edx-django-utils
 packaging==20.4           # via bleach, pytest
 pathlib2==2.3.5           # via pytest
 pbr==5.5.0                # via -r requirements/base.txt, stevedore
@@ -35,7 +35,7 @@ pluggy==0.13.1            # via pytest
 psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 py==1.9.0                 # via pytest
 pycodestyle==2.6.0        # via -r requirements/test.in
-pygments==2.7.0           # via readme-renderer
+pygments==2.7.1           # via readme-renderer
 pyjwt==1.7.1              # via -r requirements/base.txt
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,7 +12,7 @@ coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox


### PR DESCRIPTION
- Pinned `importlib-metadata==1.7.0` as `version>1.7.0` is causing conflicts for python35 in running `make upgrade`.