### PR TITLE
unpin importlib-metadata constraint

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,6 +18,6 @@ pytz==2020.1              # via django
 requests==2.24.0          # via -r requirements/base.in, slumber
 six==1.15.0               # via stevedore
 slumber==0.7.1            # via -r requirements/base.in
-sqlparse==0.3.1           # via django
+sqlparse==0.4.1           # via django
 stevedore==1.32.0         # via edx-django-utils
 urllib3==1.25.10          # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -22,6 +22,3 @@ twine<=1.15.0
 
 # constrain django to stay on LTS
 django<2.3
-
-# importlib-metadata>1.7.0 is causing conflicts in running make upgrade on python35
-importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20        # via -r requirements/test.txt, -r requirements/travis
 chardet==3.0.4            # via -r requirements/test.txt, -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/test.txt, click-log, edx-lint, pip-tools
-codecov==2.1.9            # via -r requirements/travis.txt
+codecov==2.1.10           # via -r requirements/travis.txt
 coverage==5.3             # via -r requirements/test.txt, -r requirements/travis.txt, codecov, pytest-cov
 ddt==1.4.1                # via -r requirements/test.txt
 distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
@@ -24,7 +24,7 @@ edx-lint==1.5.2           # via -r requirements/test.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 freezegun==1.0.0          # via -r requirements/test.txt
 idna==2.10                # via -r requirements/test.txt, -r requirements/travis.txt, requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
+importlib-metadata==2.0.0  # via -r requirements/test.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
@@ -53,18 +53,18 @@ pytest-django==3.10.0     # via -r requirements/test.txt
 pytest==6.1.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, freezegun
 pytz==2020.1              # via -r requirements/test.txt, django
-readme-renderer==26.0     # via -r requirements/test.txt, twine
+readme-renderer==27.0     # via -r requirements/test.txt, twine
 requests-toolbelt==0.9.1  # via -r requirements/test.txt, twine
 requests==2.24.0          # via -r requirements/test.txt, -r requirements/travis.txt, codecov, requests-toolbelt, responses, slumber, twine
 responses==0.12.0         # via -r requirements/test.txt
 six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, -r requirements/travis.txt, astroid, bleach, edx-lint, mock, packaging, pathlib2, pip-tools, python-dateutil, readme-renderer, responses, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/test.txt
-sqlparse==0.3.1           # via -r requirements/test.txt, django
+sqlparse==0.4.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via -r requirements/test.txt, edx-django-utils
 toml==0.10.1              # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
-tox==3.20.0               # via -r requirements/travis.txt, tox-battery
-tqdm==4.50.0              # via -r requirements/test.txt, twine
+tox==3.20.1               # via -r requirements/travis.txt, tox-battery
+tqdm==4.50.2              # via -r requirements/test.txt, twine
 twine==1.15.0             # via -c requirements/constraints.txt, -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 urllib3==1.25.10          # via -r requirements/test.txt, -r requirements/travis.txt, requests, responses

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,7 @@ edx-django-utils==3.8.0   # via -r requirements/base.txt
 edx-lint==1.5.2           # via -r requirements/test.in
 freezegun==1.0.0          # via -r requirements/test.in
 idna==2.10                # via -r requirements/base.txt, requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
+importlib-metadata==2.0.0  # via pluggy, pytest
 iniconfig==1.0.1          # via pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
@@ -46,16 +46,16 @@ pytest-django==3.10.0     # via -r requirements/test.in
 pytest==6.1.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via freezegun
 pytz==2020.1              # via -r requirements/base.txt, django
-readme-renderer==26.0     # via twine
+readme-renderer==27.0     # via twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.24.0          # via -r requirements/base.txt, requests-toolbelt, responses, slumber, twine
 responses==0.12.0         # via -r requirements/test.in
 six==1.15.0               # via -r requirements/base.txt, astroid, bleach, edx-lint, mock, packaging, pathlib2, python-dateutil, readme-renderer, responses, stevedore
 slumber==0.7.1            # via -r requirements/base.txt
-sqlparse==0.3.1           # via -r requirements/base.txt, django
+sqlparse==0.4.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-django-utils
 toml==0.10.1              # via pytest
-tqdm==4.50.0              # via twine
+tqdm==4.50.2              # via twine
 twine==1.15.0             # via -c requirements/constraints.txt, -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 urllib3==1.25.10          # via -r requirements/base.txt, requests, responses

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,12 +7,12 @@
 appdirs==1.4.4            # via virtualenv
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-codecov==2.1.9            # via -r requirements/travis.in
+codecov==2.1.10           # via -r requirements/travis.in
 coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
+importlib-metadata==2.0.0  # via pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
@@ -22,7 +22,7 @@ requests==2.24.0          # via codecov
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
-tox==3.20.0               # via -r requirements/travis.in, tox-battery
+tox==3.20.1               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.10          # via requests
 virtualenv==20.0.33       # via tox
 zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
- `importlib-metadata<2.0.0` was causing conflicts in running `make upgrade` with `python3.5`.
- Unpinned `importlib-metadata` constraint after fixing the issue in https://github.com/pypa/virtualenv/pull/1953 and https://github.com/tox-dev/tox/pull/1682.