### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 edX REST API Client  |Travis|_ |Codecov|_
 =========================================
-.. |Travis| image:: https://travis-ci.org/edx/edx-rest-api-client.svg?branch=master
-.. _Travis: https://travis-ci.org/edx/edx-rest-api-client
+.. |Travis| image:: https://travis-ci.com/edx/edx-rest-api-client.svg?branch=master
+.. _Travis: https://travis-ci.com/edx/edx-rest-api-client
 
 .. |Codecov| image:: https://codecov.io/github/edx/edx-rest-api-client/coverage.svg?branch=master
 .. _Codecov: https://codecov.io/github/edx/edx-rest-api-client?branch=master


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089